### PR TITLE
feat: 赛事管理和场次管理功能

### DIFF
--- a/doc/PROJECT_STATUS.md
+++ b/doc/PROJECT_STATUS.md
@@ -1,7 +1,7 @@
 # Marathon Ranking Project Status
 
 ## 当前版本信息
-- 最新稳定版本: [新的commit id]
+- 最新稳定版本: [74989a5]
 - 最后更新: 2024-11-11
 - 部署地址: https://marathon-ranking.vercel.app
 

--- a/doc/technical-overview.md
+++ b/doc/technical-overview.md
@@ -285,5 +285,5 @@
 
 ## 7. 版本控制
 - GitHub 仓库：https://github.com/imalasong-admin/marathon-ranking
-- 最新稳定版本：[新的commit id]
+- 最新稳定版本：[74989a5]
 - 最后更新：2024-11-11

--- a/models/Race.js
+++ b/models/Race.js
@@ -1,30 +1,21 @@
+// models/Race.js
 import mongoose from 'mongoose';
 
-const RaceSchema = new mongoose.Schema({
-  name: {
-    type: String,
-    required: [true, '请输入比赛名称'],
-    unique: true,
-    trim: true
+const raceSchema = new mongoose.Schema({
+  seriesId: {           // 关联到标准赛事
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Series',      // 关联 Series 模型
+    required: true
   },
-  date: {
+  date: {               // 比赛日期
     type: Date,
-    required: [true, '请输入比赛日期']
+    required: true
   },
-  raceType: {
-    type: String,
-    required: true,
-    enum: ['全程马拉松', '超马']
+  isLocked: {           // 锁定状态
+    type: Boolean,
+    default: false
   },
-  location: {
-    type: String,
-    trim: true
-  },
-  website: {
-    type: String,
-    trim: true
-  },
-  addedBy: {
+  addedBy: {            // 添加人
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
     required: true
@@ -33,4 +24,4 @@ const RaceSchema = new mongoose.Schema({
   timestamps: true
 });
 
-export default mongoose.models.Race || mongoose.model('Race', RaceSchema);
+export default mongoose.models.Race || mongoose.model('Race', raceSchema);

--- a/models/Series.js
+++ b/models/Series.js
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose';
+
+const SeriesSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: [true, '请输入赛事名称'],
+    unique: true,
+    trim: true
+  },
+  raceType: {
+    type: String,
+    required: true,
+    enum: ['全程马拉松', '超马']
+  },
+  location: {
+    type: String,
+    trim: true
+  },
+  website: {
+    type: String,
+    trim: true
+  }
+}, {
+  timestamps: true
+});
+
+export default mongoose.models.Series || mongoose.model('Series', SeriesSchema);

--- a/pages/admin/races.js
+++ b/pages/admin/races.js
@@ -1,0 +1,285 @@
+// pages/admin/races.js
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+
+export default function RacesManagement() {
+ const { data: session, status } = useSession();
+ const router = useRouter();
+
+ // 状态管理
+ const [loading, setLoading] = useState(true);
+ const [error, setError] = useState('');
+ const [series, setSeries] = useState([]); // 标准赛事列表
+ const [showAddDialog, setShowAddDialog] = useState(false);
+ const [submitting, setSubmitting] = useState(false);
+ const [races, setRaces] = useState([]);
+ const [editId, setEditId] = useState(null);
+
+ // 表单状态
+ const [form, setForm] = useState({
+   seriesId: '',  // 选择的标准赛事ID
+   date: ''       // 比赛日期
+ });
+
+ // 权限检查和加载标准赛事数据
+ useEffect(() => {
+    const loadData = async () => {
+      if (status === 'loading') return;
+      if (!session?.user?.isAdmin) {
+        router.push('/');
+        return;
+      }
+      setLoading(true);
+      try {
+        await fetchSeries();
+        await fetchRaces();
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadData();
+  }, [status, session]);
+
+ // 获取标准赛事列表
+ const fetchSeries = async () => {
+   try {
+     const res = await fetch('/api/series');
+     const data = await res.json();
+     if (data.success) {
+       setSeries(data.series);
+     }
+   } catch (err) {
+     setError('加载标准赛事失败');
+   } finally {
+     setLoading(false);
+   }
+ };
+
+// 添加获取场次列表的函数
+const fetchRaces = async () => {
+    try {
+      const res = await fetch('/api/races');
+      const data = await res.json();
+      if (data.success) {
+        setRaces(data.races);
+      } else {
+        setError(data.message || '加载场次列表失败');
+      }
+    } catch (err) {
+      console.error('加载场次列表错误:', err);
+      setError('加载场次列表失败');
+    }
+};
+
+ // 处理提交
+ const handleSubmit = async () => {
+    if (!form.date) {
+      setError('请选择比赛时间');
+      return;
+    }
+  
+    setSubmitting(true);
+    try {
+      const url = editId ? `/api/races/${editId}` : '/api/races';
+      const method = editId ? 'PUT' : 'POST';
+  
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form)
+      });
+  
+      const data = await res.json();
+      if (data.success) {
+        await fetchRaces();
+        handleCloseDialog();
+      } else {
+        setError(data.message);
+      }
+    } catch (err) {
+      setError('保存失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+ // 关闭对话框并重置表单
+ const handleCloseDialog = () => {
+    setShowAddDialog(false);
+    setEditId(null);  // 清除编辑ID
+    setForm({
+      seriesId: '',
+      date: ''
+    });
+    setError('');
+  };
+
+  const handleToggleLock = async (race) => {
+    try {
+      const res = await fetch(`/api/races/${race._id}/toggle-lock`, {
+        method: 'PATCH'
+      });
+  
+      const data = await res.json();
+      if (data.success) {
+        await fetchRaces();  // 刷新列表
+      } else {
+        setError(data.message);
+      }
+    } catch (err) {
+      setError('操作失败');
+    }
+  };
+
+
+ const handleEdit = (race) => {
+    setEditId(race._id);  // 保存正在编辑的场次ID
+    setForm({
+      seriesId: race.seriesId._id,
+      date: new Date(race.date).toISOString().split('T')[0]
+    });
+    setShowAddDialog(true);
+  };
+
+ // 错误提示自动消失
+ useEffect(() => {
+   if (error) {
+     const timer = setTimeout(() => {
+       setError('');
+     }, 3000);
+     return () => clearTimeout(timer);
+   }
+ }, [error]);
+
+ if (loading) return <div>加载中...</div>;
+
+ return (
+   <div className="max-w-6xl mx-auto py-8 px-4">
+     {error && (
+       <div className="mb-4 bg-red-50 text-red-500 p-4 rounded-md">{error}</div>
+     )}
+
+<div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">比赛场次管理</h1>
+        <button
+          onClick={() => setShowAddDialog(true)}
+          className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700"
+        >
+          添加场次
+        </button>
+      </div>
+
+      {/* 添加场次列表 */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">赛事名称</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">类型</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">比赛时间</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">状态</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">操作</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {races.map((race) => (
+              <tr key={race._id}>
+                <td className="px-6 py-4">{race.seriesId?.name || '-'}</td>
+                <td className="px-6 py-4">{race.seriesId?.raceType || '-'}</td>
+                <td className="px-6 py-4">
+  {race.date ? new Date(race.date).toLocaleDateString('en-US', { 
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: 'UTC'  // 使用UTC时区显示
+  }) : '-'}
+</td>
+                <td className="px-6 py-4">
+                  <span className={`px-2 py-1 rounded-full text-xs ${
+                    race.isLocked ? 'bg-red-100 text-red-800' : 'bg-green-100 text-green-800'
+                  }`}>
+                    {race.isLocked ? '已锁定' : '正常'}
+                  </span>
+                </td>
+                <td className="px-6 py-4 space-x-2">
+                  <button
+                    onClick={() => handleEdit(race)}
+                    className="text-blue-600 hover:text-blue-900"
+                  >
+                    编辑
+                  </button>
+                  <button
+  onClick={() => handleToggleLock(race)}
+  className={`${race.isLocked ? 'text-green-600 hover:text-green-900' : 'text-red-600 hover:text-red-900'}`}
+>
+  {race.isLocked ? '解锁' : '锁定'}
+</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+     {showAddDialog && (
+       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
+         <div className="bg-white rounded-lg max-w-md w-full p-6">
+           <h3 className="text-lg font-semibold mb-4">添加场次</h3>
+           <div className="space-y-4">
+             <div>
+               <label className="block text-sm font-medium mb-2">选择赛事</label>
+               <select
+                 value={form.seriesId}
+                 onChange={(e) => setForm({...form, seriesId: e.target.value})}
+                 disabled={submitting}
+                 className="w-full px-3 py-2 border rounded-md"
+               >
+                 <option value="">请选择赛事</option>
+                 {series
+                   .sort((a, b) => a.name.localeCompare(b.name, 'zh-CN'))
+                   .map((s) => (
+                   <option key={s._id} value={s._id}>
+                     {s.name} ({s.raceType})
+                   </option>
+                 ))}
+               </select>
+             </div>
+             <div>
+               <label className="block text-sm font-medium mb-2">比赛时间</label>
+               <input
+                 type="date"
+                 value={form.date}
+                 onChange={(e) => setForm({...form, date: e.target.value})}
+                 disabled={submitting}
+                 min="2024-01-01"
+                 max="2026-12-31"
+                 className="w-full px-3 py-2 border rounded-md"
+               />
+             </div>
+           </div>
+           <div className="flex justify-end space-x-2 mt-6">
+             <button
+               onClick={handleCloseDialog}
+               disabled={submitting}
+               className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+             >
+               取消
+             </button>
+             <button
+               onClick={handleSubmit}
+               disabled={submitting}
+               className={`px-4 py-2 text-sm bg-blue-600 text-white rounded-md 
+                 ${submitting ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700'}`}
+             >
+               {submitting ? '保存中...' : '确认'}
+             </button>
+           </div>
+         </div>
+       </div>
+     )}
+   </div>
+ );
+}

--- a/pages/admin/series.js
+++ b/pages/admin/series.js
@@ -1,0 +1,217 @@
+// pages/admin/series.js
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+
+export default function SeriesManagement() {
+ const { data: session, status } = useSession();
+ const router = useRouter();
+
+ // 状态管理
+ const [loading, setLoading] = useState(true);
+ const [error, setError] = useState('');
+ const [series, setSeries] = useState([]);
+ const [showAddDialog, setShowAddDialog] = useState(false);
+ const [editingSeries, setEditingSeries] = useState(null);
+
+ // 表单状态
+ const [form, setForm] = useState({
+   name: '',
+   raceType: '全程马拉松',
+   location: '',
+   website: ''
+ });
+
+ // 权限检查和数据加载
+ useEffect(() => {
+   if (status === 'loading') return;
+   if (!session?.user?.isAdmin) {
+     router.push('/');
+     return;
+   }
+   fetchSeries();
+ }, [status, session]);
+
+ // 获取赛事列表
+ const fetchSeries = async () => {
+   try {
+     const res = await fetch('/api/series');
+     const data = await res.json();
+     if (data.success) {
+       setSeries(data.series);
+     }
+   } catch (err) {
+     setError('加载失败');
+   } finally {
+     setLoading(false);
+   }
+ };
+
+ // 添加/编辑赛事
+ const handleSubmit = async () => {
+   if (!form.name || !form.raceType) {
+     setError('名称和类型不能为空');
+     return;
+   }
+
+   try {
+     const url = editingSeries ? `/api/series/${editingSeries._id}` : '/api/series';
+     const method = editingSeries ? 'PUT' : 'POST';
+
+     const res = await fetch(url, {
+       method,
+       headers: { 'Content-Type': 'application/json' },
+       body: JSON.stringify(form)
+     });
+
+     const data = await res.json();
+     if (data.success) {
+       await fetchSeries();
+       handleCloseDialog();
+     } else {
+       setError(data.message);
+     }
+   } catch (err) {
+     setError('保存失败');
+   }
+ };
+
+ const handleEdit = (series) => {
+   setEditingSeries(series);
+   setForm({
+     name: series.name,
+     raceType: series.raceType,
+     location: series.location || '',
+     website: series.website || ''
+   });
+   setShowAddDialog(true);
+ };
+
+ const handleCloseDialog = () => {
+   setShowAddDialog(false);
+   setEditingSeries(null);
+   setForm({
+     name: '',
+     raceType: '全程马拉松',
+     location: '',
+     website: ''
+   });
+ };
+
+ if (loading) return <div>加载中...</div>;
+
+ return (
+   <div className="max-w-6xl mx-auto py-8 px-4">
+     {error && (
+       <div className="mb-4 bg-red-50 text-red-500 p-4 rounded-md">{error}</div>
+     )}
+
+     <div className="bg-white rounded-lg shadow-sm p-6">
+       <div className="flex justify-between items-center mb-6">
+         <h1 className="text-2xl font-bold">赛事管理</h1>
+         <button
+           onClick={() => setShowAddDialog(true)}
+           className="bg-blue-600 text-white px-4 py-2 rounded-md"
+         >
+           添加赛事
+         </button>
+       </div>
+
+       <div className="overflow-x-auto">
+         <table className="min-w-full divide-y divide-gray-200">
+           <thead className="bg-gray-50">
+             <tr>
+               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">赛事名称</th>
+               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">类型</th>
+               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">地点</th>
+               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">操作</th>
+             </tr>
+           </thead>
+           <tbody className="bg-white divide-y divide-gray-200">
+             {series.map((s) => (
+               <tr key={s._id}>
+                 <td className="px-6 py-4">{s.name}</td>
+                 <td className="px-6 py-4">{s.raceType}</td>
+                 <td className="px-6 py-4">{s.location || '-'}</td>
+                 <td className="px-6 py-4 space-x-2">
+                   <button
+                     onClick={() => handleEdit(s)}
+                     className="text-blue-600 hover:text-blue-900"
+                   >
+                     编辑
+                   </button>
+
+                 </td>
+               </tr>
+             ))}
+           </tbody>
+         </table>
+       </div>
+     </div>
+
+     {showAddDialog && (
+       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
+         <div className="bg-white rounded-lg max-w-md w-full p-6">
+           <h3 className="text-lg font-semibold mb-4">
+             {editingSeries ? '编辑赛事' : '添加赛事'}
+           </h3>
+           <div className="space-y-4">
+             <div>
+               <label className="block text-sm font-medium mb-2">赛事名称</label>
+               <input
+                 type="text"
+                 value={form.name}
+                 onChange={(e) => setForm({...form, name: e.target.value})}
+                 className="w-full px-3 py-2 border rounded-md"
+               />
+             </div>
+             <div>
+               <label className="block text-sm font-medium mb-2">类型</label>
+               <select
+                 value={form.raceType}
+                 onChange={(e) => setForm({...form, raceType: e.target.value})}
+                 className="w-full px-3 py-2 border rounded-md"
+               >
+                 <option value="全程马拉松">全程马拉松</option>
+                 <option value="超马">超马</option>
+               </select>
+             </div>
+             <div>
+               <label className="block text-sm font-medium mb-2">地点</label>
+               <input
+                 type="text"
+                 value={form.location}
+                 onChange={(e) => setForm({...form, location: e.target.value})}
+                 className="w-full px-3 py-2 border rounded-md"
+               />
+             </div>
+             <div>
+               <label className="block text-sm font-medium mb-2">官网</label>
+               <input
+                 type="text"
+                 value={form.website}
+                 onChange={(e) => setForm({...form, website: e.target.value})}
+                 className="w-full px-3 py-2 border rounded-md"
+               />
+             </div>
+           </div>
+           <div className="flex justify-end space-x-2 mt-6">
+             <button
+               onClick={handleCloseDialog}
+               className="px-4 py-2 text-sm text-gray-600"
+             >
+               取消
+             </button>
+             <button
+               onClick={handleSubmit}
+               className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md"
+             >
+               确认
+             </button>
+           </div>
+         </div>
+       </div>
+     )}
+   </div>
+ );
+}

--- a/pages/api/races/[id].js
+++ b/pages/api/races/[id].js
@@ -1,0 +1,60 @@
+// pages/api/races/[id].js
+import connectDB from '../../../lib/mongodb';
+import Race from '../../../models/Race';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+export default async function handler(req, res) {
+  await connectDB();
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session?.user?.isAdmin) {
+    return res.status(403).json({ success: false, message: '需要管理员权限' });
+  }
+
+  const { id } = req.query;
+
+  if (req.method === 'PUT') {
+    try {
+      const { date } = req.body;
+
+      if (!date) {
+        return res.status(400).json({ 
+          success: false, 
+          message: '日期不能为空' 
+        });
+      }
+
+      // 调整时区
+    
+      const adjustedDate = new Date(date + 'T12:00:00.000Z');  // 直接使用UTC时间
+
+      const updatedRace = await Race.findByIdAndUpdate(
+        id,
+        { date: adjustedDate },
+        { new: true }
+      );
+
+      if (!updatedRace) {
+        return res.status(404).json({ 
+          success: false, 
+          message: '场次不存在' 
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+        message: '更新成功',
+        race: updatedRace
+      });
+    } catch (error) {
+      console.error('更新场次错误:', error);
+      res.status(500).json({ 
+        success: false, 
+        message: '更新失败，请重试' 
+      });
+    }
+  } else {
+    res.status(405).json({ message: '不支持的请求方法' });
+  }
+}

--- a/pages/api/races/[id]/toggle-lock.js
+++ b/pages/api/races/[id]/toggle-lock.js
@@ -1,0 +1,39 @@
+// pages/api/races/[id]/toggle-lock.js
+import connectDB from '../../../../lib/mongodb';
+import Race from '../../../../models/Race';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../../auth/[...nextauth]";
+
+export default async function handler(req, res) {
+  if (req.method !== 'PATCH') {
+    return res.status(405).json({ message: '不支持的请求方法' });
+  }
+
+  await connectDB();
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session?.user?.isAdmin) {
+    return res.status(403).json({ success: false, message: '需要管理员权限' });
+  }
+
+  try {
+    const { id } = req.query;
+    const race = await Race.findById(id);
+
+    if (!race) {
+      return res.status(404).json({ success: false, message: '场次不存在' });
+    }
+
+    race.isLocked = !race.isLocked;
+    await race.save();
+
+    res.status(200).json({
+      success: true,
+      message: race.isLocked ? '场次已锁定' : '场次已解锁',
+      race
+    });
+  } catch (error) {
+    console.error('切换场次锁定状态错误:', error);
+    res.status(500).json({ success: false, message: '操作失败，请重试' });
+  }
+}

--- a/pages/api/races/index.js
+++ b/pages/api/races/index.js
@@ -1,0 +1,89 @@
+// pages/api/races/index.js
+import connectDB from '../../../lib/mongodb';
+import Race from '../../../models/Race';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+export default async function handler(req, res) {
+  await connectDB();
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session?.user?.isAdmin) {
+    return res.status(403).json({ success: false, message: '需要管理员权限' });
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const { seriesId, date } = req.body;
+      console.log('收到的数据:', { seriesId, date });  // 添加这行
+  
+      // 验证必填字段
+      if (!seriesId || !date) {
+        return res.status(400).json({ 
+          success: false, 
+          message: '请选择赛事和日期' 
+        });
+      }
+
+      // 调整时区，确保保存的是当天中午12点
+      const adjustedDate = new Date(date);
+      adjustedDate.setHours(12, 0, 0, 0);
+     
+      
+      // 检查是否已存在相同场次
+      const existingRace = await Race.findOne({
+        seriesId,
+        date: adjustedDate
+      });
+
+      if (existingRace) {
+        return res.status(400).json({
+          success: false,
+          message: '该赛事在此日期已有场次'
+        });
+      }
+
+      // 创建新场次
+      const race = await Race.create({
+        seriesId,
+        date: new Date(date),  // 直接保存，不做时区调整
+        addedBy: session.user.id
+      });
+
+      res.status(201).json({
+        success: true,
+        message: '添加成功',
+        race
+      });
+
+    } catch (error) {
+      console.error('添加比赛场次错误:', error);
+      res.status(500).json({ 
+        success: false, 
+        message: '添加失败，请重试' 
+      });
+    }
+  } 
+  else if (req.method === 'GET') {
+    try {
+      // 获取场次列表时关联查询赛事信息
+      const races = await Race.find()
+        .populate('seriesId', 'name raceType')  // 关联查询赛事名称和类型
+        .sort({ date: -1 });                    // 按日期倒序
+
+      res.status(200).json({ 
+        success: true, 
+        races 
+      });
+    } catch (error) {
+      console.error('获取场次列表错误:', error);
+      res.status(500).json({ 
+        success: false, 
+        message: '获取场次列表失败' 
+      });
+    }
+  }
+  else {
+    res.status(405).json({ message: '不支持的请求方法' });
+  }
+}

--- a/pages/api/series/[id].js
+++ b/pages/api/series/[id].js
@@ -1,0 +1,81 @@
+import connectDB from '../../../lib/mongodb';
+import Series from '../../../models/Series';
+import { getServerSession } from "next-auth/next";  
+import { authOptions } from "../auth/[...nextauth]";  
+
+export default async function handler(req, res) {
+  await connectDB();
+  const session = await getServerSession(req, res, authOptions);
+  const { id } = req.query;
+
+  if (!session) {
+    return res.status(401).json({ success: false, message: '请先登录' });
+  }
+
+  if (!session.user.isAdmin) {
+    return res.status(403).json({ success: false, message: '需要管理员权限' });
+  }
+
+
+  switch(req.method) {
+    case 'GET':
+      try {
+        const series = await Series.findById(id);
+        if (!series) {
+          return res.status(404).json({ success: false, message: '赛事不存在' });
+        }
+        res.status(200).json({ success: true, series });
+      } catch (error) {
+        res.status(500).json({ success: false, message: '获取失败' });
+      }
+      break;
+
+    case 'PUT':
+      try {
+        const { name, raceType, location, website } = req.body;
+        
+        if (!name || !raceType) {
+          return res.status(400).json({ 
+            success: false, 
+            message: '名称和类型不能为空' 
+          });
+        }
+
+        // 检查名称是否重复(排除自身)
+        const existingSeries = await Series.findOne({
+          _id: { $ne: id },
+          name: { $regex: new RegExp(`^${name}$`, 'i') }
+        });
+
+        if (existingSeries) {
+          return res.status(400).json({
+            success: false,
+            message: '该赛事名称已存在'
+          });
+        }
+
+        const updatedSeries = await Series.findByIdAndUpdate(
+          id,
+          { name, raceType, location, website },
+          { new: true, runValidators: true }
+        );
+
+        if (!updatedSeries) {
+          return res.status(404).json({ success: false, message: '赛事不存在' });
+        }
+
+        res.status(200).json({
+          success: true,
+          message: '更新成功',
+          series: updatedSeries
+        });
+      } catch (error) {
+        console.error('更新赛事错误:', error);
+        res.status(500).json({ success: false, message: '更新失败，请重试' });
+      }
+      break;
+
+    default:
+      res.status(405).json({ message: '不支持的请求方法' });
+  }
+}   

--- a/pages/api/series/index.js
+++ b/pages/api/series/index.js
@@ -1,0 +1,77 @@
+import connectDB from '../../../lib/mongodb';
+import Series from '../../../models/Series';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+
+export default async function handler(req, res) {
+  await connectDB();
+  const session = await getServerSession(req, res, authOptions);
+
+  console.log('API session:', session); // 调试用
+
+  if (!session) {
+    return res.status(401).json({ success: false, message: '请先登录' });
+  }
+
+  if (!session.user.isAdmin) {
+    return res.status(403).json({ success: false, message: '需要管理员权限' });
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const series = await Series.find({})
+        .sort({ name: 1 });
+      res.status(200).json({ success: true, series });
+    } catch (error) {
+      console.error('获取赛事列表错误:', error);
+      res.status(500).json({ success: false, message: '获取赛事列表失败' });
+    }
+  } 
+  else if (req.method === 'POST') {
+    // 检查管理员权限
+    if (!session.user.isAdmin) {
+      return res.status(403).json({ success: false, message: '需要管理员权限' });
+    }
+
+    try {
+      const { name, raceType, location, website } = req.body;
+
+      if (!name || !raceType) {
+        return res.status(400).json({ 
+          success: false, 
+          message: '赛事名称和类型不能为空' 
+        });
+      }
+
+      const existingSeries = await Series.findOne({ 
+        name: { $regex: new RegExp(`^${name}$`, 'i') }
+      });
+      
+      if (existingSeries) {
+        return res.status(400).json({ 
+          success: false, 
+          message: '该赛事名称已存在' 
+        });
+      }
+
+      const series = await Series.create({
+        name,
+        raceType,
+        location: location || '',
+        website: website || ''
+      });
+
+      res.status(201).json({ 
+        success: true, 
+        message: '添加成功',
+        series
+      });
+    } catch (error) {
+      console.error('添加赛事错误:', error);
+      res.status(500).json({ success: false, message: '添加失败，请重试' });
+    }
+  } 
+  else {
+    res.status(405).json({ message: '不支持的请求方法' });
+  }
+}


### PR DESCRIPTION
- 创建标准赛事库管理功能
 - 赛事的添加和编辑
 - 赛事列表展示
 - 基本信息维护（名称、类型、地点、官网）

- 实现比赛场次管理功能
 - 基于标准赛事添加场次
 - 场次列表展示
 - 场次编辑功能
 - 场次锁定/解锁功能

- 更新数据模型
 - Series模型：标准赛事数据结构
 - Race模型：更新为关联Series的结构

- 更新文档
 - 更新 PROJECT_STATUS.md：添加新完成功能
 - 更新 technical-overview.md：更新数据模型和API说明